### PR TITLE
FLOE-224: Fix header overlap on News pages in Safari.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -70,7 +70,7 @@ body {
     margin-left: 1.8em;
     margin-top: 2em;
     height: 4em;
-    display: inline-block;
+    display: inline;
 }
 
 .floe-header h1 {


### PR DESCRIPTION
No other issues apparent.
