### PR TITLE
FLOE-450: Updated index page with new links to content.

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,9 +152,8 @@
                         that will help OER developers more easily create sound-based representations of interactive data
                         that can increase comprehension and reinforce learning.
                         </p>
-                    <p>The <a href="http://build.fluidproject.org/chartAuthoring/demos/">Chart Authoring</a> tool demonstrates
-                        how audio can enhance comprehension of data. This demo works best with a browser supporting the
-                        Web Speech API like Google Chrome.
+                        <p>The <a href="http://build.fluidproject.org/chartAuthoring/demos/">Chart Authoring</a> tool demonstrates
+                        how audio can enhance comprehension of data.
                         </p>
 
                         <!--
@@ -178,8 +177,8 @@
                         <a href="http://handbook.floeproject.org/WebGamesAndSimulations.html">inclusive web games and simulations</a>.</p>
 
                         <p>Floe is creating <a href="https://wiki.fluidproject.org/display/fluid/Inclusive+Design+Guidelines+for+Good+Practice">Inclusive
-                            Design Guidelines for Good Practice</a> - an engaging resource for learning about and applying Inclusive Design prinples, practices,
-                            and tools to the design process.
+                        Design Guidelines for Good Practice</a> - an engaging resource for learning about and applying Inclusive Design principles, practices,
+                        and tools to the design process.
                         </p>
 
                         <p>The <a href="http://metadata.floeproject.org/demos/metadata/">Metadata Editor</a>

--- a/index.html
+++ b/index.html
@@ -114,6 +114,9 @@
                             <p>The <a href="http://build.fluidproject.org/prefsEditors/demos/explorationTool/">Preference Exploration Tool</a>
                                 offers a set of starter preferences to try - from reading content aloud so it's easier to follow along,
                                 to enhancing keyboard interactions so it's easier to use.</p>
+                            <p>The <a href="https://wiki.fluidproject.org/display/fluid/%28Floe%29+Preference+Exploration+and+Self-Assessment">
+                                Self Assessment Dashboard</a> helps learners keep track of their progress, and personalize their learning goals and
+                                learning experience through self-reflection.</p>
                         </div>
                     </li>
                 </ul>
@@ -139,7 +142,7 @@
                         <div class="floe-image floe-image-videoPlayer"></div>
                     </li>
                     <li class="floe-story-textBeside">
-                        <h2>Looking for help making multimedia more inclusive?</h2>
+                        <h2>Looking for help making rich content more inclusive?</h2>
                         <p>The
                         <a href="http://build.fluidproject.org/videoPlayer/demos/Mammals.html">HTML5 Video Player</a>
                         offers full keyboard access, captions, transcripts, descriptions and responds to personal user preferences.
@@ -148,6 +151,12 @@
                         <a href="https://wiki.fluidproject.org/display/fluid/%28Floe%29+Sonification">sonification framework</a>
                         that will help OER developers more easily create sound-based representations of interactive data
                         that can increase comprehension and reinforce learning.
+                        </p>
+                    <p>The <a href="http://build.fluidproject.org/chartAuthoring/demos/">Chart Authoring</a> tool demonstrates
+                        how audio can enhance comprehension of data. This demo works best with a browser supporting the
+                        Web Speech API like Google Chrome.
+                        </p>
+
                         <!--
                         This framework is being used to add audio respresentations
                         of data to our <a href="http://build.fluidproject.org/chartAuthoring/demos/">Chart Authoring Tool</a>.</p>
@@ -167,6 +176,12 @@
                         <a href="http://handbook.floeproject.org/InclusiveEPUB3.html">inclusive EPUB 3 resources</a>,
                         <a href="http://handbook.floeproject.org/AccessibleStandardizedTesting.html">accessible standardized tests</a>, and
                         <a href="http://handbook.floeproject.org/WebGamesAndSimulations.html">inclusive web games and simulations</a>.</p>
+
+                        <p>Floe is creating <a href="https://wiki.fluidproject.org/display/fluid/Inclusive+Design+Guidelines+for+Good+Practice">Inclusive
+                            Design Guidelines for Good Practice</a> - an engaging resource for learning about and applying Inclusive Design prinples, practices,
+                            and tools to the design process.
+                        </p>
+
                         <p>The <a href="http://metadata.floeproject.org/demos/metadata/">Metadata Editor</a>
                         makes it simple to provide useful labels regarding the learner preferences the resource can meet,
                         and supports authors in adding accessibility features.


### PR DESCRIPTION
I have added text and links to new Floe content:
- self-assessment dashboard
- chart authoring
- inclusive design guidelines (aka. cards)

You can see the site in my gh-pages branch here: https://jhung.github.io/floeproject.org/

@michelled can you take a look at this and see that it is okay?