### PR TITLE
FLOE-446: change link to infusion in floeproject.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,7 +215,7 @@
                             <dt><a href="http://outside-in.idrc.ocadu.ca/">Outside-IN</a></dt>
                             <dd>Outside-IN provides individualized youth training and mentorship programs. Floe is working with Outside-IN, creating tools to support youth engagement.</dd>
                             <dt><a href="http://raisingthefloor.org/">Raising the Floor</a></dt>
-                            <dd><a href="http://gpii.net/">The Global Public Inclusive Infrastructure (GPII)</a>, a project of Raising the Floor, is building upon the foundation of Learner Options to create preference editing tools. This global project makes extensive use of <a href="https://github.com/fluid-project/infusion-docs/">Fluid Infusion</a>.</dd>
+                            <dd><a href="http://gpii.net/">The Global Public Inclusive Infrastructure (GPII)</a>, a project of Raising the Floor, is building upon the foundation of Learner Options to create preference editing tools. This global project makes extensive use of <a href="http://fluidproject.org/infusion.html">Fluid Infusion</a>.</dd>
                             <dt><a href="http://wiki.gpii.net/index.php/Developer_Space">Prosperity4All Developer Space</a></dt>
                             <dd>Floe is working with the GPII on the development of the Prosperity4All Developer Space (D-Space), which will support developers in finding, using, and contributing to inclusive software development.</dd>
                             <dt><a href="https://pressbooks.com/">Pressbooks</a></dt>


### PR DESCRIPTION
made it http://fluidproject.org/infusion.html instead of https://github.com/fluid-project/infusion-docs/ 