### PR TITLE
Adding page about UI Options to the site (Fixes #91)

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
-                            <li><a href="news/index.html">News</a></li>
-                            <li><a href="resources.html">Resources</a></li>
+                            <li><a href="./news/index.html">News</a></li>
+                            <li><a href="./resources.html">Resources</a></li>
+                            <li><a href="./ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>
@@ -124,8 +125,8 @@
                             <div class="floe-image floe-image-UIO"></div>
                             <h2>Want to select, refine and apply your preferences?</h2>
                             <p>Preference editing tools help learners personalize their learning experience.
-                               <a href="http://build.fluidproject.org/infusion/demos/prefsFramework/">Learner Options</a>
-                               allow selection and fine-tuning of preferences.</p>
+                               <a href="http://build.fluidproject.org/infusion/demos/prefsFramework/">Learner / UI Options</a>
+                               allow selection and fine-tuning of preferences. <a href="./ui-options.html">Learn more</a> about adding it to your site or application.</p>
                         </div>
 
                         <div class="columns large-6 small-12">

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="./news/index.html">News</a></li>
                             <li><a href="./resources.html">Resources</a></li>
-                            <li><a href="./ui-options.html">Learner UI Options</a></li>
+                            <li><a href="./ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>
@@ -125,7 +125,7 @@
                             <div class="floe-image floe-image-UIO"></div>
                             <h2>Want to select, refine and apply your preferences?</h2>
                             <p>Preference editing tools help learners personalize their learning experience.
-                               <a href="http://build.fluidproject.org/infusion/demos/prefsFramework/">Learner / UI Options</a>
+                               <a href="http://build.fluidproject.org/infusion/demos/prefsFramework/">UI Options</a>
                                allow selection and fine-tuning of preferences. <a href="./ui-options.html">Learn more</a> about adding it to your site or application.</p>
                         </div>
 

--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
                             <h2>Want to select, refine and apply your preferences?</h2>
                             <p>Preference editing tools help learners personalize their learning experience.
                                <a href="http://build.fluidproject.org/infusion/demos/prefsFramework/">UI Options</a>
-                               allow selection and fine-tuning of preferences. <a href="./ui-options.html">Learn more</a> about adding it to your site or application.</p>
+                               allows selection and fine-tuning of preferences. <a href="./ui-options.html">Learn more</a> about adding it to your site or application.</p>
                         </div>
 
                         <div class="columns large-6 small-12">

--- a/news/2012-02-28-updates-to-ildh.html
+++ b/news/2012-02-28-updates-to-ildh.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2012-02-28-updates-to-ildh.html
+++ b/news/2012-02-28-updates-to-ildh.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2012-03-06-webinar-outside-in.html
+++ b/news/2012-03-06-webinar-outside-in.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2012-03-06-webinar-outside-in.html
+++ b/news/2012-03-06-webinar-outside-in.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2012-10-12-project-update.html
+++ b/news/2012-10-12-project-update.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2012-10-12-project-update.html
+++ b/news/2012-10-12-project-update.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2012-10-15-floe-open-ed.html
+++ b/news/2012-10-15-floe-open-ed.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2012-10-15-floe-open-ed.html
+++ b/news/2012-10-15-floe-open-ed.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2012-10-19-plans-for-floe-year-three.html
+++ b/news/2012-10-19-plans-for-floe-year-three.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2012-10-19-plans-for-floe-year-three.html
+++ b/news/2012-10-19-plans-for-floe-year-three.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2012-10-24-jutta-zoomer-mag.html
+++ b/news/2012-10-24-jutta-zoomer-mag.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2012-10-24-jutta-zoomer-mag.html
+++ b/news/2012-10-24-jutta-zoomer-mag.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2012-12-05-floe-deployment-feasibility-study-funded.html
+++ b/news/2012-12-05-floe-deployment-feasibility-study-funded.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2012-12-05-floe-deployment-feasibility-study-funded.html
+++ b/news/2012-12-05-floe-deployment-feasibility-study-funded.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2012-12-05-floe-leads-inclusive-design-workshop-at-big-ideas-fest.html
+++ b/news/2012-12-05-floe-leads-inclusive-design-workshop-at-big-ideas-fest.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2012-12-05-floe-leads-inclusive-design-workshop-at-big-ideas-fest.html
+++ b/news/2012-12-05-floe-leads-inclusive-design-workshop-at-big-ideas-fest.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2013-03-05-fluid-releases-new-video-player.html
+++ b/news/2013-03-05-fluid-releases-new-video-player.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2013-03-05-fluid-releases-new-video-player.html
+++ b/news/2013-03-05-fluid-releases-new-video-player.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2013-11-05-call-for-contributions-wai-accessible-e-learning-online-symposium.html
+++ b/news/2013-11-05-call-for-contributions-wai-accessible-e-learning-online-symposium.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2013-11-05-call-for-contributions-wai-accessible-e-learning-online-symposium.html
+++ b/news/2013-11-05-call-for-contributions-wai-accessible-e-learning-online-symposium.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2013-11-12-inclusive-design-of-oers.html
+++ b/news/2013-11-12-inclusive-design-of-oers.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2013-11-12-inclusive-design-of-oers.html
+++ b/news/2013-11-12-inclusive-design-of-oers.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2014-03-01-edupub2-workshop.html
+++ b/news/2014-03-01-edupub2-workshop.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2014-03-01-edupub2-workshop.html
+++ b/news/2014-03-01-edupub2-workshop.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2014-03-10-harnessing-the-open-web.html
+++ b/news/2014-03-10-harnessing-the-open-web.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2014-03-10-harnessing-the-open-web.html
+++ b/news/2014-03-10-harnessing-the-open-web.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2014-03-18-metadata-editing-components.html
+++ b/news/2014-03-18-metadata-editing-components.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2014-03-18-metadata-editing-components.html
+++ b/news/2014-03-18-metadata-editing-components.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2014-03-24-floe-presentations-at-csun.html
+++ b/news/2014-03-24-floe-presentations-at-csun.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2014-03-24-floe-presentations-at-csun.html
+++ b/news/2014-03-24-floe-presentations-at-csun.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2014-03-28-workshop-inclusive-technology-in-the-classroom.html
+++ b/news/2014-03-28-workshop-inclusive-technology-in-the-classroom.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2014-03-28-workshop-inclusive-technology-in-the-classroom.html
+++ b/news/2014-03-28-workshop-inclusive-technology-in-the-classroom.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2014-04-04-panel-presentation-a11y-in-oer.html
+++ b/news/2014-04-04-panel-presentation-a11y-in-oer.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2014-04-04-panel-presentation-a11y-in-oer.html
+++ b/news/2014-04-04-panel-presentation-a11y-in-oer.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2014-04-15-floe-at-hci.html
+++ b/news/2014-04-15-floe-at-hci.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2014-04-15-floe-at-hci.html
+++ b/news/2014-04-15-floe-at-hci.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2014-04-21-metadata-search.html
+++ b/news/2014-04-21-metadata-search.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2014-04-21-metadata-search.html
+++ b/news/2014-04-21-metadata-search.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2014-09-30-lumen-learning.html
+++ b/news/2014-09-30-lumen-learning.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2014-09-30-lumen-learning.html
+++ b/news/2014-09-30-lumen-learning.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2015-01-13-oer-a11y-sprint.html
+++ b/news/2015-01-13-oer-a11y-sprint.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2015-01-13-oer-a11y-sprint.html
+++ b/news/2015-01-13-oer-a11y-sprint.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2015-03-26-uio-wp-plugin.html
+++ b/news/2015-03-26-uio-wp-plugin.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2015-03-26-uio-wp-plugin.html
+++ b/news/2015-03-26-uio-wp-plugin.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2015-05-08-workshop-business-advantages.html
+++ b/news/2015-05-08-workshop-business-advantages.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2015-11-16-phet.html
+++ b/news/2015-11-16-phet.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2015-11-16-phet.html
+++ b/news/2015-11-16-phet.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2016-03-28-upcoming-talks-on-inclusive-digital-education.html
+++ b/news/2016-03-28-upcoming-talks-on-inclusive-digital-education.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2016-03-28-upcoming-talks-on-inclusive-digital-education.html
+++ b/news/2016-03-28-upcoming-talks-on-inclusive-digital-education.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2016-11-30-DEEP-conference-2016.html
+++ b/news/2016-11-30-DEEP-conference-2016.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2016-11-30-DEEP-conference-2016.html
+++ b/news/2016-11-30-DEEP-conference-2016.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2016-11-30-IIDEX-2016.html
+++ b/news/2016-11-30-IIDEX-2016.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2016-11-30-IIDEX-2016.html
+++ b/news/2016-11-30-IIDEX-2016.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2016-11-30-UN-international-day-of-persons-with-disabilities.html
+++ b/news/2016-11-30-UN-international-day-of-persons-with-disabilities.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2016-11-30-UN-international-day-of-persons-with-disabilities.html
+++ b/news/2016-11-30-UN-international-day-of-persons-with-disabilities.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2017-07-19-inclusive-science-lab.html
+++ b/news/2017-07-19-inclusive-science-lab.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2017-07-19-inclusive-science-lab.html
+++ b/news/2017-07-19-inclusive-science-lab.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2017-08-30-self-assessment-toolkit.html
+++ b/news/2017-08-30-self-assessment-toolkit.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2017-08-30-self-assessment-toolkit.html
+++ b/news/2017-08-30-self-assessment-toolkit.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2017-12-11-cast-cisl.html
+++ b/news/2017-12-11-cast-cisl.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2017-12-11-cast-cisl.html
+++ b/news/2017-12-11-cast-cisl.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2018-01-31-uioPlus.html
+++ b/news/2018-01-31-uioPlus.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2018-01-31-uioPlus.html
+++ b/news/2018-01-31-uioPlus.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2018-04-18-New-Content-Added-to-Inclusive-Design-Resources.html
+++ b/news/2018-04-18-New-Content-Added-to-Inclusive-Design-Resources.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2018-04-18-New-Content-Added-to-Inclusive-Design-Resources.html
+++ b/news/2018-04-18-New-Content-Added-to-Inclusive-Design-Resources.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2018-06-19-El-Planeta-Es-La-Escuela.html
+++ b/news/2018-06-19-El-Planeta-Es-La-Escuela.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2018-06-19-El-Planeta-Es-La-Escuela.html
+++ b/news/2018-06-19-El-Planeta-Es-La-Escuela.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>
@@ -102,7 +103,7 @@
                     As part of a series of activities happening under the project
                     <a href="https://karisma.org.co/el-planeta-es-la-escuela/">‘El Planeta Es La Escuela’</a>
                     and the Social Justice Repair Kit (SJRK) project, Karisma Foundation organised a 3-day gathering that took place on May 24th-26th at
-                    <a href="http://platohedro.org">Platohedro</a> in Medellín, Colombia. Members of the Floe team joined rural students from the agricultural 
+                    <a href="http://platohedro.org">Platohedro</a> in Medellín, Colombia. Members of the Floe team joined rural students from the agricultural
                     region of Fresno and women from <a href="http://platohedro.org/motivando-a-la-gyal/">Motivando a la Gyal</a>  for a series of workshops, storytelling and knowledge sharing.
                     During the workshops participants explored ideas of inclusion and diversity using activities such as collaborative art making as a
                     starting point for both individual and group storytelling.

--- a/news/2018-08-30-Cities-Co-Design.html
+++ b/news/2018-08-30-Cities-Co-Design.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2018-08-30-Cities-Co-Design.html
+++ b/news/2018-08-30-Cities-Co-Design.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2018-09-17-GSoC2018.html
+++ b/news/2018-09-17-GSoC2018.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2018-09-17-GSoC2018.html
+++ b/news/2018-09-17-GSoC2018.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2018-11-08-DEEP2018.html
+++ b/news/2018-11-08-DEEP2018.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2018-11-08-DEEP2018.html
+++ b/news/2018-11-08-DEEP2018.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2019-01-24-ResistanceInWire.html
+++ b/news/2019-01-24-ResistanceInWire.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2019-01-24-ResistanceInWire.html
+++ b/news/2019-01-24-ResistanceInWire.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2019-02-07-CISL-site-and-demo.html
+++ b/news/2019-02-07-CISL-site-and-demo.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2019-02-07-CISL-site-and-demo.html
+++ b/news/2019-02-07-CISL-site-and-demo.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2019-03-20-NROC-2019.html
+++ b/news/2019-03-20-NROC-2019.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2019-03-20-NROC-2019.html
+++ b/news/2019-03-20-NROC-2019.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2019-03-22-OCAD-OE-week.html
+++ b/news/2019-03-22-OCAD-OE-week.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2019-03-22-OCAD-OE-week.html
+++ b/news/2019-03-22-OCAD-OE-week.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2019-06-28-Code-Learn-Create.html
+++ b/news/2019-06-28-Code-Learn-Create.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2019-06-28-Code-Learn-Create.html
+++ b/news/2019-06-28-Code-Learn-Create.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2019-07-02-Guelph-accessibility-conference.html
+++ b/news/2019-07-02-Guelph-accessibility-conference.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2019-07-02-Guelph-accessibility-conference.html
+++ b/news/2019-07-02-Guelph-accessibility-conference.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2019-08-12-Coding-Prototype-Co-design.html
+++ b/news/2019-08-12-Coding-Prototype-Co-design.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2019-08-12-Coding-Prototype-Co-design.html
+++ b/news/2019-08-12-Coding-Prototype-Co-design.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2019-10-23-SJRK-F2F.html
+++ b/news/2019-10-23-SJRK-F2F.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2019-10-23-SJRK-F2F.html
+++ b/news/2019-10-23-SJRK-F2F.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2019-11-05-Design-2-Align.html
+++ b/news/2019-11-05-Design-2-Align.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/2019-11-05-Design-2-Align.html
+++ b/news/2019-11-05-Design-2-Align.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/YYYY-MM-DD-news-item-title.html
+++ b/news/YYYY-MM-DD-news-item-title.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/YYYY-MM-DD-news-item-title.html
+++ b/news/YYYY-MM-DD-news-item-title.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/index.html
+++ b/news/index.html
@@ -86,7 +86,7 @@
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="../ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/news/index.html
+++ b/news/index.html
@@ -72,7 +72,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="/index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -81,11 +81,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
                             <li><a href="index.html">News</a></li>
                             <li><a href="../resources.html">Resources</a></li>
+                            <li><a href="../ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/resources.html
+++ b/resources.html
@@ -73,7 +73,7 @@
 
         <div class="floe">
             <div class="row">
-                <div class="columns small-12 medium-9 large-9">
+                <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
                         <h1><a rel="home" title="Home" href="index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
@@ -82,11 +82,12 @@
                         </h1>
                     </header>
                 </div>
-                <div class="columns small-12 medium-3 large-3 align-self-bottom">
+                <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
-                            <li><a href="news/index.html">News</a></li>
-                            <li><a href="resources.html">Resources</a></li>
+                          <li><a href="./news/index.html">News</a></li>
+                          <li><a href="./resources.html">Resources</a></li>
+                          <li><a href="./ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/resources.html
+++ b/resources.html
@@ -87,7 +87,7 @@
                         <ul>
                           <li><a href="./news/index.html">News</a></li>
                           <li><a href="./resources.html">Resources</a></li>
-                          <li><a href="./ui-options.html">Learner UI Options</a></li>
+                          <li><a href="./ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>

--- a/ui-options.html
+++ b/ui-options.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
     <head>
-        <title>Learner UI Options | floe</title>
+        <title>UI Options | floe</title>
         <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
         <link type="image/x-icon" href="images/favicon.ico" rel="shortcut icon"/>
@@ -87,7 +87,7 @@
                         <ul>
                             <li><a href="./news/index.html">News</a></li>
                             <li><a href="./resources.html">Resources</a></li>
-                            <li><a href="./ui-options.html">Learner UI Options</a></li>
+                            <li><a href="./ui-options.html">UI Options</a></li>
                         </ul>
                     </nav>
                 </div>
@@ -98,11 +98,11 @@
 
                 <!-- Begin UI Options Information Container -->
                 <article>
-                  <h2>About Learner / UI Options</h2>
+                  <h2>About UI Options</h2>
                   <p>
-                  Learner Options (or "UI Options") provides a way to enhance or improve website usability, flexibility, and accessibility by providing a way to customize and control aspects of a website without the need for additional software or tools. For those who design, build, or maintain websites, UI Options can also help reveal areas where the web content and structure can be changed to improve flexibility and robustness.
+                  User Interface Options (or UI Options) provides a way to enhance or improve website usability, flexibility, and accessibility by providing a way to customize and control aspects of a website without the need for additional software or tools. For those who design, build, or maintain websites, UI Options can also help reveal areas where the web content and structure can be changed to improve flexibility and robustness.
                   </p>
-                  <h3>Get Learner / UI Options</h3>
+                  <h3>Get UI Options</h3>
                   <p>
                   For Wordpress: <a href="https://github.com/fluid-project/uio-wordpress-plugin">UI Options Wordpress Plugin</a>.
                   </p>
@@ -112,10 +112,10 @@
                   </p>
                   <h3>Guides and Documentation</h3>
                   <p>
-                  If installing Learner / UI Options using npm or from a release on GitHub (not applicable if using the Wordpress plugin), "<a href="https://docs.fluidproject.org/infusion/development/tutorial-userInterfaceOptions/UserInterfaceOptions.html">Setting Up User Interface Options</a>" will help installing and structuring your code.
+                  If installing UI Options using npm or from a release on GitHub (not applicable if using the Wordpress plugin), "<a href="https://docs.fluidproject.org/infusion/development/tutorial-userInterfaceOptions/UserInterfaceOptions.html">Setting Up User Interface Options</a>" will help installing and structuring your code.
                   </p>
                   <p>
-                  Once Learner / UI Options is installed, <a href="https://docs.fluidproject.org/infusion/development/tutorial-userInterfaceOptions/WorkingWithUserInterfaceOptions.html">"Working with UI Options"</a> can help guide you through setting up your site's styles and markup to take advantage of Learner / UI Options.
+                  Once UI Options is installed, <a href="https://docs.fluidproject.org/infusion/development/tutorial-userInterfaceOptions/WorkingWithUserInterfaceOptions.html">"Working with UI Options"</a> can help guide you through setting up your site's styles and markup to take advantage of UI Options.
                   </p>
                 </article>
 

--- a/ui-options.html
+++ b/ui-options.html
@@ -108,11 +108,11 @@
                   </p>
 
                   <p>
-                  For code projects: <a href="https://www.npmjs.com/package/infusion">using npm</a>, or <a href="https://github.com/fluid-project/infusion/releases">GitHub</a>.
+                  From source code: <a href="https://www.npmjs.com/package/infusion">using npm</a>, or <a href="https://github.com/fluid-project/infusion/releases">GitHub</a>.
                   </p>
                   <h3>Guides and Documentation</h3>
                   <p>
-                  If installing Learner / UI Options using npm or from a github release, "<a href="https://docs.fluidproject.org/infusion/development/tutorial-userInterfaceOptions/UserInterfaceOptions.html">Setting Up User Interface Options</a>" will help installing and structuring your code (Note: this is not applicable if using the Wordpress plugin).
+                  If installing Learner / UI Options using npm or from a release on GitHub (not applicable if using the Wordpress plugin), "<a href="https://docs.fluidproject.org/infusion/development/tutorial-userInterfaceOptions/UserInterfaceOptions.html">Setting Up User Interface Options</a>" will help installing and structuring your code.
                   </p>
                   <p>
                   Once Learner / UI Options is installed, <a href="https://docs.fluidproject.org/infusion/development/tutorial-userInterfaceOptions/WorkingWithUserInterfaceOptions.html">"Working with UI Options"</a> can help guide you through setting up your site's styles and markup to take advantage of Learner / UI Options.

--- a/ui-options.html
+++ b/ui-options.html
@@ -1,23 +1,23 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
     <head>
-        <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+        <title>Learner UI Options | floe</title>
+        <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
-        <title>News: The Business Advantages of Making Special the Norm | floe</title>
-        <link type="image/x-icon" href="../images/favicon.ico" rel="shortcut icon"/>
+        <link type="image/x-icon" href="images/favicon.ico" rel="shortcut icon"/>
 
         <!-- Foundation flex grid -->
-        <link href="../lib/foundation/foundation.css" rel="stylesheet" type="text/css" />
+        <link href="lib/foundation/foundation.css" rel="stylesheet" type="text/css" />
 
-        <link href="../css/style.css" media="all" rel="stylesheet" type="text/css"/>
-        <link href="../css/print.css" media="print" rel="stylesheet" type="text/css"/>
+        <link href="css/style.css" media="all" rel="stylesheet" type="text/css" />
+        <link href="css/print.css" media="print" rel="stylesheet" type="text/css" />
 
-        <link rel="stylesheet" type="text/css" href="../lib/infusion/src/lib/normalize/css/normalize.css" />
-        <link rel="stylesheet" type="text/css" href="../lib/infusion/src/framework/core/css/fluid.css" />
+        <link rel="stylesheet" type="text/css" href="lib/infusion/src/lib/normalize/css/normalize.css" />
+        <link rel="stylesheet" type="text/css" href="lib/infusion/src/framework/core/css/fluid.css" />
 
-        <link rel="stylesheet" type="text/css" href="../lib/infusion/src/framework/preferences/css/Enactors.css" />
-        <link rel="stylesheet" type="text/css" href="../lib/infusion/src/framework/preferences/css/PrefsEditor.css" />
-        <link rel="stylesheet" type="text/css" href="../lib/infusion/src/framework/preferences/css/SeparatedPanelPrefsEditor.css" />
+        <link rel="stylesheet" type="text/css" href="lib/infusion/src/framework/preferences/css/Enactors.css" />
+        <link rel="stylesheet" type="text/css" href="lib/infusion/src/framework/preferences/css/PrefsEditor.css" />
+        <link rel="stylesheet" type="text/css" href="lib/infusion/src/framework/preferences/css/SeparatedPanelPrefsEditor.css" />
 
         <!--[if lte IE 8]>
         <script type="text/javascript">document.createElement("header")</script>
@@ -27,13 +27,14 @@
         <script type="text/javascript">document.createElement("aside")</script>
         <![endif]-->
 
-        <script type="text/javascript" src="../lib/infusion/infusion-custom.js"></script>
-        <script type="text/javascript" src="../js/floe.js"></script>
+        <script type="text/javascript" src="lib/infusion/infusion-custom.js"></script>
+        <script type="text/javascript" src="js/floe.js"></script>
+        <script type="text/javascript" src="js/resources.js"></script>
     </head>
     <body>
         <script type="text/javascript">
             $(document).ready(function () {
-                floe.setupUIO("../");
+                floe.setupUIO("");
             });
         </script>
 
@@ -74,7 +75,7 @@
             <div class="row">
                 <div class="columns small-12 medium-12 large-7">
                     <header class="floe-header">
-                        <h1><a rel="home" title="Home" href="../index.html" class="floe-header-logo">floe
+                        <h1><a rel="home" title="Home" href="index.html" class="floe-header-logo">floe
                             <span class="floe-header-tagline">
                                 flexible learning for open education
                             </span></a>
@@ -84,46 +85,43 @@
                 <div class="columns small-12 medium-12 large-5 align-self-bottom">
                     <nav class="floe-nav">
                         <ul>
-                            <li><a href="index.html">News</a></li>
-                            <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ui-options.html">Learner UI Options</a></li>
+                            <li><a href="./news/index.html">News</a></li>
+                            <li><a href="./resources.html">Resources</a></li>
+                            <li><a href="./ui-options.html">Learner UI Options</a></li>
                         </ul>
                     </nav>
                 </div>
             </div>
 
-            <div class="flc-toc-tocContainer toc"> </div>
-            <article class="floe-content floe-news-item">
-                <h2> News </h2>
+            <div id="content" class="floe-content">
+                <div class="flc-toc-tocContainer toc"> </div>
 
-                <h3>Workshop: The Business Advantages of Making Special the Norm</h3>
-                <time class="floe-date" datetime="2015-05-08">May 8, 2015</time>
-                <p>The <a href="http://www.viscardicenter.org/services/nbdc/">National Business and
-                    Disability Council (NBDC)</a> at <a href="http://www.viscardicenter.org/">The Viscardi Center</a>
-                     is offering an educational online workshop to focus on designing for diversity.</p>
-                <p>No one needs to point out that the current business climate is in a state of flux
-                    and transformation. To thrive requires a good measure of agility, responsiveness,
-                    continuous innovation and dynamic resiliency. These qualities are the by-products of
-                    broadly diverse perspectives, skills, and approaches combined with the conditions
-                    that foster their inclusion. Fortuitously, emerging technologies and associated
-                    practices make it viable to move beyond mass design – in policy, communication,
-                    product development, service, marketing, training and other business practices –
-                    and make special the norm. If we proactively design for diversity we not only comply
-                    with legislative requirements for accessibility but we also reap the benefits of
-                    flexibility, adaptability and a spectrum of possible approaches, to thrive in a
-                    quickly evolving business climate.</p>
-                    <ul>
-                        <li><strong>Date</strong>: May 20, 2015</li>
-                        <li><strong>Time</strong>: 2:00 – 3:00pm</li>
-                        <li><strong>Location</strong>: Online, Webinar</li>
-                    </ul>
-                <p>The workshop will be presented by Jutta Treviranus, Director of the
-                    <a href="http://idrc.ocadu.ca/">Inclusive Design Research Centre (IDRC)</a>
-                    and professor at <a href="http://ocadu.ca">OCAD University</a> in Toronto.</p>
-                <p>For more information or to register, visit <a href="http://www.viscardicenter.org/news-events/events/nbdc-distance-learning.html">http://www.viscardicenter.org/news-events/events/nbdc-distance-learning.html</a>.</p>
+                <!-- Begin UI Options Information Container -->
+                <article>
+                  <h2>About Learner / UI Options</h2>
+                  <p>
+                  Learner Options (or "UI Options") provides a way to enhance or improve website usability, flexibility, and accessibility by providing a way to customize and control aspects of a website without the need for additional software or tools. For those who design, build, or maintain websites, UI Options can also help reveal areas where the web content and structure can be changed to improve flexibility and robustness.
+                  </p>
+                  <h3>Get Learner / UI Options</h3>
+                  <p>
+                  For Wordpress: <a href="https://github.com/fluid-project/uio-wordpress-plugin">UI Options Wordpress Plugin</a>.
+                  </p>
 
-                <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/cjXKHzcQypw" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
-            </article>
+                  <p>
+                  For code projects: <a href="https://www.npmjs.com/package/infusion">using npm</a>, or <a href="https://github.com/fluid-project/infusion/releases">GitHub</a>.
+                  </p>
+                  <h3>Guides and Documentation</h3>
+                  <p>
+                  If installing Learner / UI Options using npm or from a github release, "<a href="https://docs.fluidproject.org/infusion/development/tutorial-userInterfaceOptions/UserInterfaceOptions.html">Setting Up User Interface Options</a>" will help installing and structuring your code (Note: this is not applicable if using the Wordpress plugin).
+                  </p>
+                  <p>
+                  Once Learner / UI Options is installed, <a href="https://docs.fluidproject.org/infusion/development/tutorial-userInterfaceOptions/WorkingWithUserInterfaceOptions.html">"Working with UI Options"</a> can help guide you through setting up your site's styles and markup to take advantage of Learner / UI Options.
+                  </p>
+                </article>
+
+                <!-- End UI Options Information Container -->
+
+            </div>
 
             <footer class="floe-footer">
                 <div class="floe-content row">
@@ -156,6 +154,5 @@
                 </div>
             </footer>
         </div>
-
     </body>
 </html>


### PR DESCRIPTION
Adding a page about UI Options to the Floe site to make it easier for integrators to find and install UI Options.

This can be expanded and updated at a later time with more detailed information (for example the UIO "Lunchbox" can replace this).

Fixes #91 