### PR TITLE
Add AT template in technical details section of bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,5 +36,9 @@ If applicable, add screenshots to help explain your problem.
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
 
+### Assistive technology used
+ - Name: [Name of assistive technology]
+ - Version: [e.g. 22] 
+
 ## Additional context or notes
 Add any other context about the problem here.


### PR DESCRIPTION
Fixes #94 

Added a section for AT used under technical details in bug_report.md.

Please let me know if any more changes need to be made in relation to this. Thanks!