### PR TITLE
FLOE :- Fixed overlapping of highlighted links in the home page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -533,6 +533,7 @@ figcaption details p {
     text-decoration: none;
     border-bottom: none;
     padding: 0 0.2em;
+    font-size: .83em;
 }
 
 .floe-content.floe-story a:hover,


### PR DESCRIPTION
This pr solves the issue of highlighted links overlapping with each other.
Issue solved #108 
These are the cases when the line width is minimum which is .7
After this PR:-

Without resizing the window :-
![Screenshot from 2020-03-01 02-33-42](https://user-images.githubusercontent.com/55639487/75615031-001dd100-5b65-11ea-9b75-1aad82351821.png)

Resizing the window to its minimum width:-
![Screenshot from 2020-03-01 02-33-51](https://user-images.githubusercontent.com/55639487/75615042-1af04580-5b65-11ea-903b-cd3fd343e592.png)
