### PR TITLE
FLOE-578: removed ignored CSS properties

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -67,8 +67,6 @@ body {
 /* FLOE Header area, tagline, and logo. */
 .floe-header {
     margin-left: 1.8em;
-    margin-top: 2em;
-    height: 4em;
     display: inline;
 }
 


### PR DESCRIPTION
Margin-top and height are ignored due to the display property. With 'display: inline', the width, height, margin-top, margin-bottom, and float properties have no effect. It makes no sense to set margin and height properties when the display has been set to inline. 