### PR TITLE
FLOE-579: overlapping links in footer fixed

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -204,6 +204,10 @@ body {
     width: 46.6%;
 }
 
+div.columns.large-6.small-12 a {
+    display: inline-block;
+}
+
 /* BEGIN The grid of featured work */
 .floe-featured-list {
     list-style: none outside none;


### PR DESCRIPTION
**1)** Fixes #121 

![Screenshot from 2020-03-02 05-44-34](https://user-images.githubusercontent.com/34926285/75636921-ec4b9b00-5c48-11ea-85a5-0969c1ad8c7a.png)

**2)** Simultaneously fixes #108

![Screenshot from 2020-03-02 05-47-26](https://user-images.githubusercontent.com/34926285/75636979-519f8c00-5c49-11ea-8650-85bf61811510.png)

**3)** fixes #114  too since it's a duplicate issue.