### PR TITLE
FLOE-580: fixed nav bar items splitting for small screen devices

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -121,6 +121,12 @@ body {
     background-color: #FFCB00;
 }
 
+.floe-nav a{
+    display: inline-block;
+    margin-top: 5px;
+    white-space: nowrap;
+}
+
 /* FLOE Content Containers - not header. Header has its own styles above. */
 .floe-content {
     font-family: 'Roboto Slab', serif;


### PR DESCRIPTION
fixes #123 
Added margin-top and display properties so as to avoid overlapping of "UI Options" link with the "News" link as described in #123 (Additional content column). 
Simultaneously fixes #106 