### PR TITLE
fixed overlapping of images with text when text size is reduced to 0.5

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -556,11 +556,11 @@ figcaption details p {
     margin-bottom: 2em;
 }
 
-.floe .floe-image-UIO             { background: url("../images/floe-02.png") no-repeat 0 0 / 325px 325px; }
-.floe .floe-image-exploreTool     { background: url("../images/floe-01.png") no-repeat 0 0 / 325px 325px; }
-.floe .floe-image-cloud           { background: url("../images/floe-05.png") no-repeat 0 0 / 325px 325px; }
-.floe .floe-image-preferenceIcons { background: url("../images/floe-04.png") no-repeat 0 0 / 325px 325px; }
-.floe .floe-image-videoPlayer     { background: url("../images/floe-03.png") no-repeat 0 0 / 325px 325px; }
+.floe .floe-image-UIO             { background: url("../images/floe-02.png") no-repeat 0 0 / 290px 290px; }
+.floe .floe-image-exploreTool     { background: url("../images/floe-01.png") no-repeat 0 0 / 290px 290px; }
+.floe .floe-image-cloud           { background: url("../images/floe-05.png") no-repeat 0 0 / 290px 290px; }
+.floe .floe-image-preferenceIcons { background: url("../images/floe-04.png") no-repeat 0 0 / 280px 280px; }
+.floe .floe-image-videoPlayer     { background: url("../images/floe-03.png") no-repeat 0 0 / 280px 280px; }
 
 .floe-image-caption {
     background-color: white;


### PR DESCRIPTION
Overlapping of the image with the text when text size is reduced to 0.5 is fixed.
Issue number #105 

**Before:**

![Capture](https://user-images.githubusercontent.com/51847351/75697242-cbc82300-5cd2-11ea-823d-952e9d8f44d5.JPG)

**After:**

![Capture1](https://user-images.githubusercontent.com/51847351/75697308-e4d0d400-5cd2-11ea-8de5-abda13a9276d.JPG)

