### PR TITLE
fixed ui options splitting.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -121,6 +121,13 @@ body {
     background-color: #FFCB00;
 }
 
+/* On screens that are 326px or less, set the navbar links font-size to 13.6px */
+@media screen and (max-width: 326px) {
+    .floe-nav {
+      font-size: 13.6px;
+    }
+  }
+
 /* FLOE Content Containers - not header. Header has its own styles above. */
 .floe-content {
     font-family: 'Roboto Slab', serif;


### PR DESCRIPTION
The ui options now remain in the same line when we resize the window to the minimum width.

Screenshot:-
![Screenshot from 2020-03-03 20-01-48](https://user-images.githubusercontent.com/55639487/75785574-faed9b80-5d89-11ea-91b6-2c6aa9bb75ee.png)
this pr solves issue #123 
