### PR TITLE
Removing unused code.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -541,10 +541,6 @@ figcaption details p {
     background-color: transparent;
 }
 
-.floe-story-cloud {
-    margin-top: 12em;
-}
-
 .floe .floe-image {
     width: 325px;
     height: 325px;

--- a/css/style.css
+++ b/css/style.css
@@ -558,22 +558,6 @@ figcaption details p {
 .floe .floe-image-preferenceIcons { background: url("../images/floe-04.png") no-repeat 0 0 / 325px 325px; }
 .floe .floe-image-videoPlayer     { background: url("../images/floe-03.png") no-repeat 0 0 / 325px 325px; }
 
-.floe-image-caption {
-    background-color: white;
-    font-family: 'Open Sans', sans-serif;
-    font-style: italic;
-    padding: 0.8em;
-    font-size: 0.8em;
-}
-
-.floe-image-caption-heading {
-    font-family: 'Open Sans', sans-serif;
-    display: block;
-    font-style: normal;
-    font-weight: bold;
-    font-size: 0.85em;
-    margin-bottom: 0;
-}
 .floe-story-textBeside {
     margin-top: 1em;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -432,10 +432,6 @@ body {
     font-size: 1.2em;
 }
 
-.floe-news-item ul {
-    margin-left: 2em;
-}
-
 .floe-news-item h3 {
     background-color: #efefef;
 }


### PR DESCRIPTION
Removing the unused code in the website.
.floe-news-iems does not use margin-left as it uses padding.

Screenshots before:-

![Screenshot from 2020-03-08 22-48-02](https://user-images.githubusercontent.com/55639487/76167738-fca2cf00-618e-11ea-9a99-320f366a86e0.png)

Screenshot after:-
![Screenshot from 2020-03-08 22-48-19](https://user-images.githubusercontent.com/55639487/76167752-12b08f80-618f-11ea-9598-52e9ef9a9250.png)

