### PR TITLE
Removed CNAME file

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.floeproject.org


### PR DESCRIPTION
No need to keep the CNAME file since the website is not hosted using gh-pages. Therefore, the file for a custom domain is not required. 