### PR TITLE
FLOE-583: Update the UI Options page

### DIFF
--- a/ui-options.html
+++ b/ui-options.html
@@ -93,35 +93,58 @@
                 </div>
             </div>
 
-            <div id="content" class="floe-content">
+            <main id="content" class="floe-content">
                 <div class="flc-toc-tocContainer toc"> </div>
 
                 <!-- Begin UI Options Information Container -->
                 <article>
                   <h2>About UI Options</h2>
                   <p>
-                  User Interface Options (or UI Options) provides a way to enhance or improve website usability, flexibility, and accessibility by providing a way to customize and control aspects of a website without the need for additional software or tools. For those who design, build, or maintain websites, UI Options can also help reveal areas where the web content and structure can be changed to improve flexibility and robustness.
+                      <abbr title="User Interface Options">UI Options</abbr> allows a user to customize a website to their own personal needs and preferences. It offers a variety of adaptations/customization including: text size, text style, line spacing, contrast themes, table of contents, enhance inputs and more.
                   </p>
-                  <h3>Get UI Options</h3>
                   <p>
-                  For Wordpress: <a href="https://github.com/fluid-project/uio-wordpress-plugin">UI Options Wordpress Plugin</a>.
+                      For the site integrator, UI Options is another step in the accessibility and inclusivity of your website. Through UI Options' user driven customizations, a broader audience is able to access your content and materials.
                   </p>
 
+                  <h3>See UI Options in action</h3>
                   <p>
-                  From source code: <a href="https://www.npmjs.com/package/infusion">using npm</a>, or <a href="https://github.com/fluid-project/infusion/releases">GitHub</a>.
+                      UI Options is integrated here on the <a href="index.html">Floe Project</a> site and can be access through the <strong>show preferences</strong> tab along the top of the page.
+                  </p>
+                  <p>
+                      The <a href="https://build.fluidproject.org/infusion/demos/uiOptions/">UI Options Demo</a> is where to try out the latest in development version.
+                  </p>
+                  
+                  <h2>Integrator Information</h2>
+                  <h3>Obtain UI Options</h3>
+                  <p>
+                      UI Options is available as part of <a href="https://fluidproject.org/infusion.html">Fluid Infusion</a>. You can obtain a copy of Infusion directly from <a href="https://github.com/fluid-project/infusion/">GitHub</a> or through <a href="https://www.npmjs.com/package/infusion">NPM</a>.
+                  </p>
+
+                  <h4><abbr title="Content Management System">CMS</abbr> Integrations</h4>
+                  <p>
+                      Plugins for some content management systems are available.
+
+                      <ul>
+                        <li>
+                            <a href="https://github.com/fluid-project/uio-wordpress-plugin">Wordpress</a>
+                        </li>
+                        <li>
+                            <a href="https://www.drupal.org/project/fluidui">Drupal</a> - maintained by <a href="https://openconcept.ca">OpenConcept</a>
+                        </li>
+                      </ul>
                   </p>
                   <h3>Guides and Documentation</h3>
                   <p>
-                  If installing UI Options using npm or from a release on GitHub (not applicable if using the Wordpress plugin), "<a href="https://docs.fluidproject.org/infusion/development/tutorial-userInterfaceOptions/UserInterfaceOptions.html">Setting Up User Interface Options</a>" will help installing and structuring your code.
+                      If installing UI Options using NPM or from a release on GitHub, "<a href="https://docs.fluidproject.org/infusion/development/tutorial-userInterfaceOptions/UserInterfaceOptions.html">Setting Up User Interface Options</a>" will help installing and structuring your code.
                   </p>
                   <p>
-                  Once UI Options is installed, <a href="https://docs.fluidproject.org/infusion/development/tutorial-userInterfaceOptions/WorkingWithUserInterfaceOptions.html">"Working with UI Options"</a> can help guide you through setting up your site's styles and markup to take advantage of UI Options.
+                      Once UI Options is installed, "<a href="https://docs.fluidproject.org/infusion/development/tutorial-userInterfaceOptions/WorkingWithUserInterfaceOptions.html">Working with UI Options</a>" can help guide you through setting up your website's styles and markup to take advantage of UI Options.
                   </p>
                 </article>
 
                 <!-- End UI Options Information Container -->
 
-            </div>
+            </main>
 
             <footer class="floe-footer">
                 <div class="floe-content row">


### PR DESCRIPTION
https://issues.fluidproject.org/browse/FLOE-583

I've made a pass at updating the copy of the UI Options page. I haven't added in images or other things that may require extra styling work because I'm finding it difficult to maintain consistency with the rest of the site styling using the foundation framework included. This is partially because unclear if it is a subset of foundation 6 that is missing parts or if I'm just not locating the correct docs for the version we're using. 

I'm thinking that we can either update this page further with the site redesign, or I could take a stab a modernizing the CSS for the entire site at this time as well. I'd lean towards the former as we are in the midst of migrating this site to a SSG in a GSoC project this year.