### PR TITLE
added support for javascript incompatible devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,10 @@
                     <button class="flc-slidingPanel-toggleButton fl-prefsEditor-showHide"> Show/Hide</button>
                     <button class="flc-prefsEditor-reset fl-prefsEditor-reset"><span class="fl-icon-undo"></span> Reset</button>
                 </span>
+                <noscript>
+                    <meta content="1">
+                    <a target="_blank" href="https://www.google.com/search?q=how+enable+javascript" style="color: red;">Enable JavaScript to use this tool</a>
+                </noscript>
             </div>
 
             <!-- This is the div that will contain the Preference Editor component -->
@@ -61,6 +65,10 @@
                 <span class="fl-prefsEditor-buttons">
                     <button class="flc-slidingPanel-toggleButton fl-prefsEditor-showHide"> Show/Hide</button>
                     <button class="flc-prefsEditor-reset fl-prefsEditor-reset"><span class="fl-icon-undo"></span> Reset</button>
+                    <noscript>
+                        <meta content="1">
+                        <a target="_blank" href="https://www.google.com/search?q=how+enable+javascript" style="color: red;">Enable JavaScript to use this tool</a>
+                    </noscript>
                 </span>
             </div>
         </div>


### PR DESCRIPTION
Devices that don' support javascript will have a notification link telling them to enable javascript inorder to use the preference tool.The notification is also a link that points to steps on how to enable javascript on their devices