### PR TITLE
Fix :Text overlapping to image when we reduced the text-size

### DIFF
--- a/src/assets/stylesheets/style.css
+++ b/src/assets/stylesheets/style.css
@@ -558,11 +558,11 @@ figcaption details p {
     margin-bottom: 2em;
 }
 
-.floe .floe-image-UIO             { background: url("../images/floe-02.png") no-repeat 0 0 / 325px 325px; }
-.floe .floe-image-exploreTool     { background: url("../images/floe-01.png") no-repeat 0 0 / 325px 325px; }
-.floe .floe-image-cloud           { background: url("../images/floe-05.png") no-repeat 0 0 / 325px 325px; }
-.floe .floe-image-preferenceIcons { background: url("../images/floe-04.png") no-repeat 0 0 / 325px 325px; }
-.floe .floe-image-videoPlayer     { background: url("../images/floe-03.png") no-repeat 0 0 / 325px 325px; }
+.floe .floe-image-UIO             { background: url("../images/floe-02.png") no-repeat 0 0 / 100%; max-width: 100%; }
+.floe .floe-image-exploreTool     { background: url("../images/floe-01.png") no-repeat 0 0 / 100%; max-width: 100%; }
+.floe .floe-image-cloud           { background: url("../images/floe-05.png") no-repeat 0 0 / 100% 100%; max-width: 100%; }
+.floe .floe-image-preferenceIcons { background: url("../images/floe-04.png") no-repeat 0 0 / 100%; max-width: 100%; }
+.floe .floe-image-videoPlayer     { background: url("../images/floe-03.png") no-repeat 0 0 / 100%; max-width: 100%; }
 
 .floe-image-caption {
     background-color: white;
@@ -641,35 +641,35 @@ address {
 }
 
 /* Themed images */
-.fl-theme-bw .floe .floe-image-UIO             { background: url("../images/bw-floe-02.png") no-repeat 0 0 / 325px 325px; }
-.fl-theme-bw .floe .floe-image-exploreTool     { background: url("../images/bw-floe-01.png") no-repeat 0 0 / 325px 325px; }
-.fl-theme-bw .floe .floe-image-cloud           { background: url("../images/bw-floe-05.png") no-repeat 0 0 / 325px 325px; }
-.fl-theme-bw .floe .floe-image-preferenceIcons { background: url("../images/bw-floe-04.png") no-repeat 0 0 / 325px 325px; }
-.fl-theme-bw .floe .floe-image-videoPlayer     { background: url("../images/bw-floe-03.png") no-repeat 0 0 / 325px 325px; }
+.fl-theme-bw .floe .floe-image-UIO             { background: url("../images/bw-floe-02.png") no-repeat 0 0 / 100%; max-width: 100%; }
+.fl-theme-bw .floe .floe-image-exploreTool     { background: url("../images/bw-floe-01.png") no-repeat 0 0 / 100%; max-width: 100%; }
+.fl-theme-bw .floe .floe-image-cloud           { background: url("../images/bw-floe-05.png") no-repeat 0 0 / 100% 100%; max-width: 100%; }
+.fl-theme-bw .floe .floe-image-preferenceIcons { background: url("../images/bw-floe-04.png") no-repeat 0 0 / 100%; max-width: 100%; }
+.fl-theme-bw .floe .floe-image-videoPlayer     { background: url("../images/bw-floe-03.png") no-repeat 0 0 / 100%; max-width: 100%; }
 
-.fl-theme-wb .floe .floe-image-UIO             { background: url("../images/wb-floe-02.png") no-repeat 0 0 / 325px 325px; }
-.fl-theme-wb .floe .floe-image-exploreTool     { background: url("../images/wb-floe-01.png") no-repeat 0 0 / 325px 325px; }
-.fl-theme-wb .floe .floe-image-cloud           { background: url("../images/wb-floe-05.png") no-repeat 0 0 / 325px 325px; }
-.fl-theme-wb .floe .floe-image-preferenceIcons { background: url("../images/wb-floe-04.png") no-repeat 0 0 / 325px 325px; }
-.fl-theme-wb .floe .floe-image-videoPlayer     { background: url("../images/wb-floe-03.png") no-repeat 0 0 / 325px 325px; }
+.fl-theme-wb .floe .floe-image-UIO             { background: url("../images/wb-floe-02.png") no-repeat 0 0 / 100%; max-width: 100%; }
+.fl-theme-wb .floe .floe-image-exploreTool     { background: url("../images/wb-floe-01.png") no-repeat 0 0 / 100%; max-width: 100%; }
+.fl-theme-wb .floe .floe-image-cloud           { background: url("../images/wb-floe-05.png") no-repeat 0 0 / 100% 100%; max-width: 100%; }
+.fl-theme-wb .floe .floe-image-preferenceIcons { background: url("../images/wb-floe-04.png") no-repeat 0 0 / 100%; max-width: 100%; }
+.fl-theme-wb .floe .floe-image-videoPlayer     { background: url("../images/wb-floe-03.png") no-repeat 0 0 / 100%; max-width: 100%; }
 
-.fl-theme-by .floe .floe-image-UIO             { background: url("../images/by-floe-02.png") no-repeat 0 0 / 325px 325px; }
-.fl-theme-by .floe .floe-image-exploreTool     { background: url("../images/by-floe-01.png") no-repeat 0 0 / 325px 325px; }
-.fl-theme-by .floe .floe-image-cloud           { background: url("../images/by-floe-05.png") no-repeat 0 0 / 325px 325px; }
-.fl-theme-by .floe .floe-image-preferenceIcons { background: url("../images/by-floe-04.png") no-repeat 0 0 / 325px 325px; }
-.fl-theme-by .floe .floe-image-videoPlayer     { background: url("../images/by-floe-03.png") no-repeat 0 0 / 325px 325px; }
+.fl-theme-by .floe .floe-image-UIO             { background: url("../images/by-floe-02.png") no-repeat 0 0/ 100%; max-width: 100%; }
+.fl-theme-by .floe .floe-image-exploreTool     { background: url("../images/by-floe-01.png") no-repeat 0 0 / 100%; max-width: 100%; }
+.fl-theme-by .floe .floe-image-cloud           { background: url("../images/by-floe-05.png") no-repeat 0 0 / 100% 100%; max-width: 100%; }
+.fl-theme-by .floe .floe-image-preferenceIcons { background: url("../images/by-floe-04.png") no-repeat 0 0 / 100%; max-width: 100%; }
+.fl-theme-by .floe .floe-image-videoPlayer     { background: url("../images/by-floe-03.png") no-repeat 0 0 / 100%; max-width: 100%; }
 
-.fl-theme-yb .floe .floe-image-UIO             { background: url("../images/yb-floe-02.png") no-repeat 0 0 / 325px 325px; }
-.fl-theme-yb .floe .floe-image-exploreTool     { background: url("../images/yb-floe-01.png") no-repeat 0 0 / 325px 325px; }
-.fl-theme-yb .floe .floe-image-cloud           { background: url("../images/yb-floe-05.png") no-repeat 0 0 / 325px 325px; }
-.fl-theme-yb .floe .floe-image-preferenceIcons { background: url("../images/yb-floe-04.png") no-repeat 0 0 / 325px 325px; }
-.fl-theme-yb .floe .floe-image-videoPlayer     { background: url("../images/yb-floe-03.png") no-repeat 0 0 / 325px 325px; }
+.fl-theme-yb .floe .floe-image-UIO             { background: url("../images/yb-floe-02.png") no-repeat 0 0 / 100%; max-width: 100%; }
+.fl-theme-yb .floe .floe-image-exploreTool     { background: url("../images/yb-floe-01.png") no-repeat 0 0 / 100%; max-width: 100%; }
+.fl-theme-yb .floe .floe-image-cloud           { background: url("../images/yb-floe-05.png") no-repeat 0 0 / 100% 100%; max-width: 100%; }
+.fl-theme-yb .floe .floe-image-preferenceIcons { background: url("../images/yb-floe-04.png") no-repeat 0 0 / 100%; max-width: 100%; }
+.fl-theme-yb .floe .floe-image-videoPlayer     { background: url("../images/yb-floe-03.png") no-repeat 0 0 / 100%; max-width: 100%; }
 
-.fl-theme-lgdg .floe .floe-image-UIO             { background: url("../images/lgdg-floe-02.png") no-repeat 0 0 / 325px 325px; }
-.fl-theme-lgdg .floe .floe-image-exploreTool     { background: url("../images/lgdg-floe-01.png") no-repeat 0 0 / 325px 325px; }
-.fl-theme-lgdg .floe .floe-image-cloud           { background: url("../images/lgdg-floe-05.png") no-repeat 0 0 / 325px 325px; }
-.fl-theme-lgdg .floe .floe-image-preferenceIcons { background: url("../images/lgdg-floe-04.png") no-repeat 0 0 / 325px 325px; }
-.fl-theme-lgdg .floe .floe-image-videoPlayer     { background: url("../images/lgdg-floe-03.png") no-repeat 0 0 / 325px 325px; }
+.fl-theme-lgdg .floe .floe-image-UIO             { background: url("../images/lgdg-floe-02.png") no-repeat 0 0 / 100%; max-width: 100%; }
+.fl-theme-lgdg .floe .floe-image-exploreTool     { background: url("../images/lgdg-floe-01.png") no-repeat 0 0 / 100%; max-width: 100%; }
+.fl-theme-lgdg .floe .floe-image-cloud           { background: url("../images/lgdg-floe-05.png") no-repeat 0 0 / 100% 100%; max-width: 100%; }
+.fl-theme-lgdg .floe .floe-image-preferenceIcons { background: url("../images/lgdg-floe-04.png") no-repeat 0 0 / 100%; max-width: 100%; }
+.fl-theme-lgdg .floe .floe-image-videoPlayer     { background: url("../images/lgdg-floe-03.png") no-repeat 0 0 / 100%; max-width: 100%; }
 
 .row {
     max-width: 76rem;


### PR DESCRIPTION
### descriptions
The image and the text overlapping to each other when we reduced the text-style to "0.5" and the image is also not responsive in the mobile view
so, i  fixed both  this issue you can also check in the screenshots which is given below--

### issue
#189 

### screenshot before-
![now before now](https://user-images.githubusercontent.com/65535360/89925625-536e7200-dc21-11ea-9e6f-d6767b98af1a.PNG)

### screenshot after my code  -
![rk](https://user-images.githubusercontent.com/65535360/89925852-a34d3900-dc21-11ea-85cd-ffa936a4e80e.PNG)


