### PR TITLE
fix: resolve Markdown linting error

### DIFF
--- a/src/news/2020-08-28-SNOW-OER.md
+++ b/src/news/2020-08-28-SNOW-OER.md
@@ -2,9 +2,13 @@
 title: New Guide on Creating Open Educational Resources Published
 date: '2020-08-28'
 ---
-The SNOW project team has published two guides about Open Educational Resources for educators and educational content creators. The guides, created with community input, including educators and learners, offer practical ways to begin using and creating open educational resource materials whether educators are remote or in person.  
+The SNOW project team has published two guides about Open Educational Resources for educators and educational content
+creators. The guides, created with community input, including educators and learners, offer practical ways to begin
+using and creating open educational resource materials whether educators are remote or in person.
 
-OER and open education practices can support educators in meeting the learning needs of diverse cohorts by fostering a global community to contribute to the collective production of a range of learning resources to meet a learning goal for a range of learning needs.
+OER and open education practices can support educators in meeting the learning needs of diverse cohorts by fostering
+a global community to contribute to the collective production of a range of learning resources to meet a learning
+goal for a range of learning needs.
 
 The guides are published on the SNOW website for Inclusive Learning and Education, and OERCommons:
 


### PR DESCRIPTION
Resolved a Markdown linting error in the SNOW OER news item (line length exceeded 120 characters). I discovered this when running `npm run lint`.