### PR TITLE
feat: automatically generate news list on homepage

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,6 +5,7 @@ const syntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
 
 // Import filters
 const dateFilter = require('./src/filters/date-filter.js');
+const limitFilter = require('./src/filters/limit-filter.js');
 const markdownFilter = require('./src/filters/markdown-filter.js');
 
 // Import transforms
@@ -15,10 +16,17 @@ const parseTransform = require('./src/transforms/parse-transform.js');
 const site = require('./src/_data/site.json');
 
 module.exports = function(config) {
+  // Collections
+  config.addCollection('news', collection => {
+    return [
+      ...collection.getFilteredByGlob('src/news/*.md').sort((a, b) => b.data.date - a.data.date)
+    ].reverse();
+  });
+
   // Filters
   config.addFilter('dateFilter', dateFilter);
+  config.addFilter('limit', limitFilter);
   config.addFilter('markdownFilter', markdownFilter);
-
 
   // Transforms
   config.addTransform('htmlmin', htmlMinTransform);
@@ -59,8 +67,7 @@ module.exports = function(config) {
       output: 'dist',
       includes: "_includes"
     },
-    templateFormats: ["html", "md"],
-    htmlTemplateEngine: "liquid",
+    htmlTemplateEngine: "njk",
     	// 1.1 Enable elventy to pass dirs specified above
     passthroughFileCopy: true
   };

--- a/src/_includes/layouts/default.njk
+++ b/src/_includes/layouts/default.njk
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" dir="ltr">
     <head>
         <title>{% if title %} {{ title }} {% else %} {{ site.title }} {% endif %} | floe</title>
@@ -6,27 +6,32 @@
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
         <link type="image/x-icon" href="{{ '/' | url }}assets/images/favicon.ico" rel="shortcut icon"/>
         <!-- Foundation flex grid -->
-        {% include partials/foundationflexgrid.html %}
+        {% include "partials/foundationflexgrid.html" %}
         <script type="text/javascript" src="{{ '/' | url }}lib/infusion/infusion-all.js"></script>
         <script type="text/javascript" src="{{ '/' | url }}assets/js/floe.js"></script>
-        <script type="text/javascript" src="{{ '/' | url }}assets/js/analytics.js"></script> 
+        <script type="text/javascript" src="{{ '/' | url }}assets/js/analytics.js"></script>
+        {% if page.url == "/resources.html" %}
+        <script type="text/javascript" src="{{ '/' | url }}assets/js/resources.js"></script>
+        {% endif %}
+        {% if page.url == "/ui-options.html" %}
+        <script type="text/javascript" src="{{ '/' | url }}assets/js/resources.js"></script>
+        {% endif %}
     </head>
     <body>
         <script type="text/javascript">
             $(document).ready(function () {
-                floe.setupUIO("../");
+                floe.setupUIO();
             });
         </script>
-        {% include partials/uio.html %}
+        {% include "partials/uio.html" %}
         <div id="skip">
             <a href="#content">Skip to Content</a>
         </div>
         <div class="floe">
-            {% include partials/header.html %}
-            {{content}}
-            {% include partials/footer.html %}
+            {% include "partials/header.html" %}
+                {{ content | safe }}
+            {% include "partials/footer.html" %}
         </div>
     </body>
+    </head>
 </html>
-
-

--- a/src/_includes/layouts/newsindex.njk
+++ b/src/_includes/layouts/newsindex.njk
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en" dir="ltr">
     <head>
         <title>{% if title %} {{ title }} {% else %} {{ site.title }} {% endif %} | floe</title>
@@ -6,32 +6,27 @@
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
         <link type="image/x-icon" href="{{ '/' | url }}assets/images/favicon.ico" rel="shortcut icon"/>
         <!-- Foundation flex grid -->
-        {% include partials/foundationflexgrid.html %}
+        {% include "partials/foundationflexgrid.html" %}
         <script type="text/javascript" src="{{ '/' | url }}lib/infusion/infusion-all.js"></script>
         <script type="text/javascript" src="{{ '/' | url }}assets/js/floe.js"></script>
         <script type="text/javascript" src="{{ '/' | url }}assets/js/analytics.js"></script>
-        {% if page.url == "/resources.html" %}
-        <script type="text/javascript" src="{{ '/' | url }}assets/js/resources.js"></script>
-        {% endif %}
-        {% if page.url == "/ui-options.html" %}
-        <script type="text/javascript" src="{{ '/' | url }}assets/js/resources.js"></script>
-        {% endif %}
     </head>
     <body>
         <script type="text/javascript">
             $(document).ready(function () {
-                floe.setupUIO();
+                floe.setupUIO("../");
             });
         </script>
-        {% include partials/uio.html %}
+        {% include "partials/uio.html" %}
         <div id="skip">
             <a href="#content">Skip to Content</a>
         </div>
         <div class="floe">
-            {% include partials/header.html %}
-                {{content}}
-            {% include partials/footer.html %}
+            {% include "partials/header.html" %}
+            {{ content | safe }}
+            {% include "partials/footer.html" %}
         </div>
     </body>
-    </head>
 </html>
+
+

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -6,10 +6,10 @@
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
         <link type="image/x-icon" href="{{ '/' | url }}assets/images/favicon.ico" rel="shortcut icon"/>
         <!-- Foundation flex grid -->
-        {% include partials/foundationflexgrid.html %}
+        {% include "partials/foundationflexgrid.html" %}
         <script type="text/javascript" src="{{ '/' | url }}lib/infusion/infusion-all.js"></script>
         <script type="text/javascript" src="{{ '/' | url }}assets/js/floe.js"></script>
-        <script type="text/javascript" src="{{ '/' | url }}assets/js/analytics.js"></script> 
+        <script type="text/javascript" src="{{ '/' | url }}assets/js/analytics.js"></script>
     </head>
     <body>
         <script type="text/javascript">
@@ -17,12 +17,12 @@
                 floe.setupUIO("../");
             });
         </script>
-        {% include partials/uio.html %}
+        {% include "partials/uio.html" %}
         <div id="skip">
             <a href="#content">Skip to Content</a>
         </div>
         <div class="floe">
-            {% include partials/header.html %}
+            {% include "partials/header.html" %}
             <article id="content" class="floe-content floe-news-item">
                 <h2> News </h2>
                 <h3>{{ title }} </h3>
@@ -31,7 +31,7 @@
                     {% endif %}
              {{content}}
              </article>
-            {% include partials/footer.html %}
+            {% include "partials/footer.html" %}
         </div>
     </body>
 </html>

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -29,7 +29,7 @@
                 {% if permalink != "news/index.html" %}
                     <time class="floe-date" datetime="{{ date }}">{{ date | dateFilter }}</time>
                     {% endif %}
-             {{content}}
+             {{content | safe}}
              </article>
             {% include "partials/footer.html" %}
         </div>

--- a/src/filters/limit-filter.js
+++ b/src/filters/limit-filter.js
@@ -1,0 +1,5 @@
+/* eslint-env es6 */
+"use strict";
+module.exports = function (array, limit) {
+    return array.slice(0, limit);
+};

--- a/src/index.html
+++ b/src/index.html
@@ -165,13 +165,9 @@ title: Paving the way toward inclusive Open Education Resources
                 <div class="floe-front-news">
                     <h3>News</h3>
                     <ul>
-                        <li><time class="floe-date" datetime="2019-11-05">August 28, 2020</time>: <a href="./news/2020-08-28-new-guide-on-creating-open-educational-resources-published.html">New Guide on Creating Open Educational Resources Published</a></li>
-                        <li><time class="floe-date" datetime="2019-11-05">July 15, 2020</time>: <a href="./news/2020-07-15-Platform-Co-op-Update.html">Collaborative Co-Design with Cooperatives</a></li>
-                        <li><time class="floe-date" datetime="2019-11-05">July 14, 2020</time>: <a href="./news/2020-07-14-New-Resources-from-Coding-to-Learn.html">New Resources from Coding to Learn</a></li>
-                        <li><time class="floe-date" datetime="2020-07-02">July 2, 2020</time>: <a href="./news/2020-07-02-WeCountUpdate.html">We Count Update: Inclusion in the Data Economy</a></li>
-                        <li><time class="floe-date" datetime="2020-07-02">June 28, 2020</time>: <a href="./news/2020-06-28-AIHEC-Update.html">American Indian Higher Education Consortium Using Floe Tools and Resources</a></li>
-                        <li><time class="floe-date" datetime="2020-05-20">May 20, 2020</time>: <a href="./news/2020-05-20-DEEP-Update.html">Webinar with Dr. Toon Calders on July 9, 2020: Machine Learning: Bias in, Bias out</a></li>
-                        <li><time class="floe-date" datetime="2020-03-27">March 27, 2020</time>: <a href="./news/2020-03-27-ODAO-Update.html">Updates from Our Doors are Open</a></li>
+                        {% for post in collections.news | limit(7) %}
+                        <li><time class="floe-date" datetime="{{ post.data.date }}">{{ post.data.date | dateFilter }}</time>: <a href="{{ post.url }}">{{ post.data.title }}</a></li>
+                        {% endfor %}
                     </ul>
                 </div>
             </div>

--- a/src/news/news.json
+++ b/src/news/news.json
@@ -1,5 +1,4 @@
 {
     "layout": "layouts/post",
-    "tags": "post",
     "permalink": "/news/{% if filename %}{{ date | slug }}-{{ filename }}{% else %}{{ date | slug }}-{{ title | slug }}{% endif %}.html"
 }

--- a/src/newsindex.md
+++ b/src/newsindex.md
@@ -7,11 +7,11 @@ permalink: news/index.html
 <div class="floe-news-archive">
 <h2> News </h2>
 <ul >
-{%- for post in collections.post reversed -%}
+{% for post in collections.news %}
 <li><a href="{{ post.url }}"><p> {{ post.data.title }}</p></a>
 <time class="floe-date" datetime="{{ post.data.date }}">{{ post.data.date | dateFilter }}</time>
 </li>
-{%- endfor -%}
+{% endfor %}
 </ul>
 </div>
 </div>


### PR DESCRIPTION
Resolves #181.

## Implementation Notes

- I modified Eleventy's templating to use Nunjucks instead of Liquid, since we use Nunjucks for both the IDRC site ([inclusive-design/idrc](https://github.com/inclusive-design/idrc)) and the We Count site [inclusive-design/wecount.inclusivedesign.ca](https://github.com/inclusive-design/wecount.inclusivedesign.ca)) as well as Pinecone ([platform-coop-toolkit/pinecone](https://github.com/platform-coop-toolkit/pinecone)). This necessitated a few minor changes.
- I added a new filter, `limit`, which limits an array to a specified length, allowing us to display a shortened list of news items on the home page.
- I created a `news` collection in the Eleventy configuration file which reverses the collection of news items based on date.