### PR TITLE
chore: adding link to Discovery Cats demo

### DIFF
--- a/src/resources.html
+++ b/src/resources.html
@@ -92,8 +92,8 @@ permalink: resources.html
                             <p>This tool walks the people through a step by step process of discovering, declaring and storing digital preferences.
                             </p>
                         </li>
-                        <li><a href="https://wiki.fluidproject.org/display/fluid/Discovery+Cats+-+First+Discovery">Discovery Cats</a>
-                            <p>See some playful designs for setting user preferences and check out the <a href="https://github.com/fluid-lab/Discovery-Cat">student project</a> that turned this into a game.
+                        <li><a href="https://build-discoverycat.fluidproject.org/demo/">Discovery Cats</a>
+                            <p>Play the Discovery Cats game, and <a href="https://wiki.fluidproject.org/display/fluid/Discovery+Cats+-+First+Discovery">see some playful designs</a> for setting user preferences and check out the <a href="https://github.com/fluid-lab/Discovery-Cat">student project</a> that turned this into a game.
                             </p>
                         </li>
                     </ul>


### PR DESCRIPTION
As per @dayotte 's request in the Matrix chat, I've added the Discovery Cats demo as the resource link, and moved the link to the designs to the resource description.