### PR TITLE
fix: update all quotes to proper open-close quotes

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -96,6 +96,14 @@ module.exports = function (config) {
         }
     });
 
+    // Configure markdown to use smartquotes
+    let markdownIt = require("markdown-it");
+    let options = {
+        html: true,
+        typographer: true
+    };
+    config.setLibrary("md", markdownIt(options));
+
     return {
         dir: {
             input: "src",

--- a/src/collections/news/2017-08-30-self-assessment-toolkit.md
+++ b/src/collections/news/2017-08-30-self-assessment-toolkit.md
@@ -39,7 +39,7 @@ The following images show examples of the designs we are currently developing (s
                 in their personalized collection.
             </summary>
             <p>
-                The image shows a collection of square 'touchnotes' buttons on the left with the heading "Query: When do
+                The image shows a collection of square "touchnotes" buttons on the left with the heading "Query: When do
                 I feel most clear-headed and focused?". The touchnotes in the collection include: "Focused",
                 "Good Idea", "Meditation", "Weather", "Diet", and "Sleep". An arrow points from the "Sleep" touchnote to
                 a dialog box with prompts for more information including: "Time to bed", "How many hours?", "Woke up

--- a/src/collections/pages/about.md
+++ b/src/collections/pages/about.md
@@ -26,7 +26,7 @@ transform, augment, and personalize the learning experience.
 
 FLOE has been contributing to the [Fluid Infusion Framework](https://fluidproject.org/infusion.html) which provides a
 technical infrastructure that can be used to create tools that are flexible and transformable. One example of such a
-tool can be seen in the 'show preferences' panel at the top of this site. This tool can be implemented into any website
+tool can be seen in the “show preferences” panel at the top of this site. This tool can be implemented into any website
 and allows a learner to transform web content to meet their personal needs and preferences. More information can be
 found on the [UI Options](/ui-options) page.
 

--- a/src/collections/pages/accessibility.md
+++ b/src/collections/pages/accessibility.md
@@ -13,7 +13,7 @@ or email [idrc@ocadu.ca](mailto:idrc@ocadu.ca).
 Other accessibility features:
 
 * web customization with _User Interface Options (UIO)_ which include a variety of controls for text and contrast modes.
-To access the settings select "show preferences" at the top right of any page.
+To access the settings select “show preferences” at the top right of any page.
 * compatibility with screen reading software and can be navigated using a keyboard or other assistive technology.
 * alternative text for images and other graphical content.
 * use of simple language where possible.

--- a/src/collections/pages/accessibilitySprint2015.md
+++ b/src/collections/pages/accessibilitySprint2015.md
@@ -37,9 +37,9 @@ more diverse the perspectives, knowledge and skills, the better the collective o
 
 ## Sign-Up
 
-As preparation for our "barn raising" let's take stock of our workforce. Please RSVP by email.
+As preparation for our “barn raising” let's take stock of our workforce. Please RSVP by email.
 
-In your email, please send a short bio to speed up the "getting to know you" process within this large team (a paragraph
+In your email, please send a short bio to speed up the “getting to know you” process within this large team (a paragraph
 or a URL to a bio online).
 
 Also, please let us know which skills/resources/talents from the list below you will generously contribute.

--- a/src/collections/projects/inverted-wordles.md
+++ b/src/collections/projects/inverted-wordles.md
@@ -5,5 +5,5 @@ tags:
   - active
 ---
 The [Inverted Wordle](https://wecount.inclusivedesign.ca/views/inverted-wordles/) tool allows learners, educators,
-and content creators to flip the emphasis on "majority rules" seen in word clouds by highlighting minority views and
+and content creators to flip the emphasis on “majority rules” seen in word clouds by highlighting minority views and
 experiences.

--- a/src/collections/projects/pluralistic-data-infrastructure.md
+++ b/src/collections/projects/pluralistic-data-infrastructure.md
@@ -6,5 +6,5 @@ tags:
 ---
 The [pluralistic data infrastructure](https://github.com/inclusive-design/forgiving-data/) allows learners to combine
 different personal data sources to create representations that can lead to self-discovery and new pathways for learning.
-"COVID-19 Vaccination Centre Data Monitor: Accessibility Map Demonstration" is an example how multiple sources of data
+“COVID-19 Vaccination Centre Data Monitor: Accessibility Map Demonstration” is an example how multiple sources of data
 can be used to generate new insights.

--- a/src/collections/resources/finding-open-educational-resources.md
+++ b/src/collections/resources/finding-open-educational-resources.md
@@ -25,7 +25,7 @@ These sites offer OER-specific resources, such as directories or authoring tools
 * [Gooru](http://www.gooru.org/)
 
   Gooru is an educational technology non-profit that is dedicated to improving learning outcomes for all students by
-  making education equally accessible and empowering. Gooru uses a unique "GPS for learning" which allows each student
+  making education equally accessible and empowering. Gooru uses a unique “GPS for learning” which allows each student
   to customize learning paths and provides tools to educators to support those learners.
 
 * [K-12](http://www.k12.com/)

--- a/src/collections/resources/multimodal.md
+++ b/src/collections/resources/multimodal.md
@@ -5,7 +5,7 @@ title: Multimodal Presentation, Content Adaptation and Personal Preferences
 Digital design offers diverse possibilities for transformation and adaptation of learning content. How do we leverage
 these possibilities in envisioning, building and evolving tools for learning to support diverse learning needs?
 
-* [User Interface Options Video (2017)](https://www.youtube.com/watch?v=63DqNgxtsrA")
+* [User Interface Options Video (2017)](https://www.youtube.com/watch?v=63DqNgxtsrA)
 
   Learn about the Fluid Project's User Interface Options (UIO) component, how it enables people to personalise web
   content to meet their unique needs, and how to integrate it into a site. UIO is now available as a


### PR DESCRIPTION
This update adjusts all double- and single-quote characters to be opening and closing quote marks in order to improve readability.

The `excerpt` field is not included in this fix, as outlined in @jobara's [comment](https://github.com/fluid-project/floeproject.org/issues/243#issuecomment-995865144) in #243 

Resolves #243 