### PR TITLE
fix: solve screenreader issue with prev/next icons

### DIFF
--- a/src/_includes/partials/components/pagination.njk
+++ b/src/_includes/partials/components/pagination.njk
@@ -2,10 +2,20 @@
     <nav aria-label="pagination">
         <ol class="pagination inline-list">
             {% if pagination.href.previous %}
-                <li class="pagination-previous"><a href="{{ pagination.href.previous }}">{{ paginationPreviousText }}</a></li>
+                <li class="pagination-previous">
+                    <span class="pagination-previous-icon" aria-hidden="true">
+                        {% svg_sprite "arrow" %}
+                    </span>
+                    <a href="{{ pagination.href.previous }}">{{ paginationPreviousText }}</a>
+                </li>
             {% endif %}
             {% if pagination.href.next %}
-                <li class="pagination-next"><a href="{{ pagination.href.next }}">{{ paginationNextText }}</a></li>
+                <li class="pagination-next">
+                    <a href="{{ pagination.href.next }}">{{ paginationNextText }}</a>
+                    <span class="pagination-next-icon" aria-hidden="true">
+                        {% svg_sprite "arrow" %}
+                    </span>
+                </li>
             {% endif %}
         </ol>
     </nav>

--- a/src/assets/images/sprites.svg
+++ b/src/assets/images/sprites.svg
@@ -2,7 +2,7 @@
 
     <!-- Icons -->
 
-    <symbol id="arrow" width="16" height="21" viewBox="0 0 16 21">
+    <symbol id="arrow" viewBox="0 0 16 21">
         <path d="M2 19.5L13 10.5L2 1.5" stroke="var(--icon-arrowColor)" stroke-width="3" stroke-linecap="round"/>
     </symbol>
 

--- a/src/assets/styles/app.css
+++ b/src/assets/styles/app.css
@@ -56,7 +56,6 @@ body {
     --fleurLargeCircleFillColor: var(--fl-bgColor, #f0eb96);
     --fleurLargeCircleOutlineColor: var(--fl-bgColor, #f0eb96);
     --fleurPlantColor: var(--fl-fgColor, #00394c);
-    --icon-arrowColor: var(--fl-buttonBgColor, #000);
 
     background-color: var(--mainBackground);
     color: var(--mainColor);
@@ -661,6 +660,8 @@ aside h2 {
 }
 
 .resources-main button .resources-expand-icon svg {
+    --icon-arrowColor: var(--fl-buttonBgColor, #000);
+
     color: var(--fl-bgColor, var(--mainColor));
     fill: none;
     height: 1.375rem;
@@ -722,14 +723,26 @@ aside h2 {
     line-height: calc(var(--fl-lineSpace-factor, 1) * 1.57);
 }
 
+.pagination svg {
+    --icon-arrowColor: var(--fl-fgColor, var(--mainColor));
+
+    fill: none;
+    height: 0.5rem;
+    vertical-align: middle;
+    width: 1rem;
+}
+
 .pagination-previous {
     grid-column-start: start;
     justify-self: start;
 }
 
-.pagination-previous::before {
-    content: "<";
+.pagination-previous-icon {
     padding-inline-end: 0.5rem;
+}
+
+.pagination-previous-icon svg {
+    transform: rotate(180deg);
 }
 
 .pagination-next {
@@ -737,8 +750,7 @@ aside h2 {
     justify-self: end;
 }
 
-.pagination-next::after {
-    content: ">";
+.pagination-next-icon {
     padding-inline-start: 0.5rem;
 }
 


### PR DESCRIPTION
* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

This update solves issues with the previous/next link arrow icons by changing the ::before and ::after content to SVG icons

## Steps to test

1. Go to the News or Projects page in Android with Talkback enabled or iOS with VoiceOver enabled
2. Cycle through and past the "Older"/"Newer" or "Next"/"Prev" links
3. Go to the Resources page

**Expected behavior:** The arrow icons should not be announced by the screen reader software. The Resources page should still work properly with no regressions.

## Additional information

N/A

## Related issues

Resolves #247 