### PR TITLE
fix: remove unintended use of ins tag on the main page

### DIFF
--- a/src/collections/pages/index.md
+++ b/src/collections/pages/index.md
@@ -8,7 +8,7 @@ permalink: /
 
 *We build* inclusive tools that respect and support individual differences and learner differentiation.
 
-*We co-design* strategies, tools and learning experiences <ins>with</ins> learners facing barriers in education.
+*We co-design* strategies, tools and learning experiences <i>with</i> learners facing barriers in education.
 
 *We support* emerging inclusive learning communities.
 


### PR DESCRIPTION
This is an issue @carenwatkins noticed, while we were checking about link styles in Floe Project site. She thinks that instead of using underlined style for the word "with", it should be italicized.